### PR TITLE
Small tweaks to workflow

### DIFF
--- a/.github/workflows/produce_report.yml
+++ b/.github/workflows/produce_report.yml
@@ -12,18 +12,21 @@ jobs:
   run_report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.3'
+          bundler-cache: true
       - run: |
-          gem install bundler
-          bundle install
           export GITHUB_TOKEN=$(bundle exec ruby token_crafter.rb | tail -1)
           OUTPUT=$(bundle exec ruby dependabot_report.rb)
-          echo 'REPORT_OUTPUT<<EOF' >> $GITHUB_ENV
-          echo "$OUTPUT" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+
+          {
+            echo 'REPORT_OUTPUT<<EOF'
+            echo '```'
+            echo "$OUTPUT"
+            echo '```'
+            echo 'EOF'
+          } >> $GITHUB_ENV
         env:
           APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Post to Slack
@@ -32,3 +35,12 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_TOKEN }}
           slack-channel: ${{ env.SLACK_CHANNEL }}
           slack-text: ${{ env.REPORT_OUTPUT }}
+
+      - name: Send failure message
+        if: ${{ failure() }}
+        uses: archive/github-actions-slack@v2.6.0
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-channel: ${{ env.SLACK_CHANNEL }}
+          slack-optional-link_names: true
+          slack-text: ":x: :github: Something went wrong trying to run the Dependabot Report. Please check the <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}|Dependabot Report run> for more information."

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   activesupport


### PR DESCRIPTION
# What
- Using `ruby/setup-ruby` instead of deprecated `actions/setup-ruby`
   **Note:** This also handles detecting the `.ruby-version` file, caching and bundle install, etc.
- Bumping to latest `actions/checkout` version
- Some tidying up of the workflow so `actionlint` is happy (still more that can be tidied)
- Added a failure message incase anything goes wrong (example in [#slack-sandbox](https://freeagent.slack.com/archives/C9E7R3KCZ/p1675186286725889))
- Adding Linux platform to bundler for GitHub runners
- Wrapping report output in backticks to ensure Slack Formatting (example in [#slack-sandbox](https://freeagent.slack.com/archives/C9E7R3KCZ/p1675186339336649))

Also I've switched over to using the org-wide `SLACK_BOT_TOKEN`, and invited this to [#front-end-arch](https://freeagent.slack.com/archives/C0214CF01A8/p1675185670043109)